### PR TITLE
Update Chromy method to use ceiling of sample size

### DIFF
--- a/R/chromy_pps.R
+++ b/R/chromy_pps.R
@@ -112,7 +112,7 @@ chromy_inner <- function(exphits) {
 
   # Set-up vectors of I, F, lower bound of hits, and a uniform random number
   exphitscum <- cumsum(exphits)
-  exphitscum[N] <- ceiling(sum(exphits))
+  exphitscum[N] <- round(sum(exphits))
   I <- floor(exphitscum)
   F <- exphitscum - I
   hits <- rep(0, N)

--- a/R/chromy_pps.R
+++ b/R/chromy_pps.R
@@ -112,6 +112,7 @@ chromy_inner <- function(exphits) {
 
   # Set-up vectors of I, F, lower bound of hits, and a uniform random number
   exphitscum <- cumsum(exphits)
+  exphitscum[N] <- ceiling(sum(exphits))
   I <- floor(exphitscum)
   F <- exphitscum - I
   hits <- rep(0, N)


### PR DESCRIPTION
There were small instances where `floor(sum(exphits))=n-1` instead of `n`. 